### PR TITLE
Maps bug fix

### DIFF
--- a/public/js/application.js
+++ b/public/js/application.js
@@ -148,7 +148,7 @@ Yelp = {
   main: function(coordinatesObject) {
     coordinates = {
       latitude: coordinatesObject.k,
-      longitude:coordinatesObject.B
+      longitude:coordinatesObject.D
     }
 
     this.getYelpResults(coordinates);


### PR DESCRIPTION
The API's returned object changed one of the property names, thereby breaking the app.
- Google Maps displays the driving directions and midpoint
- Yelp API displays restaurants within proximity of midpoint
